### PR TITLE
Copy androidSdk property file to tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ build
 /reports
 
 # Android
-/local.properties
+local.properties

--- a/src/test/kotlin/app/cash/licensee/LicenseePluginFixtureTest.kt
+++ b/src/test/kotlin/app/cash/licensee/LicenseePluginFixtureTest.kt
@@ -259,6 +259,10 @@ class LicenseePluginFixtureTest {
   private fun createRunner(fixtureDir: File): GradleRunner {
     val gradleRoot = File(fixtureDir, "gradle").also { it.mkdir() }
     File("gradle/wrapper").copyRecursively(File(gradleRoot, "wrapper"), true)
+    val androidSdkFile = File("local.properties")
+    if (androidSdkFile.exists()) {
+      androidSdkFile.copyTo(File(fixtureDir, "local.properties"), overwrite = true)
+    }
     return GradleRunner.create()
       .withProjectDir(fixtureDir)
       .withDebug(true) // Run in-process


### PR DESCRIPTION
Without an android SDK, the test will fail. Currently, you need to set the android sdk environment variable (automatically set using Android Studio or manually) or copy the local.properties file manually (eg when using IntelliJ).
The latter is done now automatically, if the file exists.